### PR TITLE
fix: corrige typo username e branch padrão

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ xcode-select --install
 Then install dotfiles:
 
 ```sh
-export DOTFILES_GH_USER=ricardorsierra
-export DOTFILES_GH_BRANCH=master
+export DOTFILES_GH_USER=ricardosierra
+export DOTFILES_GH_BRANCH=release
 bash -c "$(curl -fsSL https://raw.github.com/$DOTFILES_GH_USER/dotfiles/$DOTFILES_GH_BRANCH/bin/dotfiles) install" && source ~/.bashrc
 ```
 
@@ -92,8 +92,8 @@ _Tested on macOS 10.15+_
 ### Linux
 
 ```sh
-export DOTFILES_GH_USER=ricardorsierra
-export DOTFILES_GH_BRANCH=master
+export DOTFILES_GH_USER=ricardosierra
+export DOTFILES_GH_BRANCH=release
 bash -c "$(wget -qO- https://raw.github.com/$DOTFILES_GH_USER/dotfiles/$DOTFILES_GH_BRANCH/bin/dotfiles) install" && source ~/.bashrc
 ```
 
@@ -123,16 +123,16 @@ Para instalar `shellcheck`: `brew install shellcheck` ou rode o init `30_osx_hom
 ### macOS
 
 ```sh
-export DOTFILES_GH_USER=ricardorsierra
-export DOTFILES_GH_BRANCH=master
+export DOTFILES_GH_USER=ricardosierra
+export DOTFILES_GH_BRANCH=release
 bash -c "$(curl -fsSL https://raw.github.com/$DOTFILES_GH_USER/dotfiles/$DOTFILES_GH_BRANCH/bin/dotfiles) install" && source ~/.bashrc
 ```
 
 ### Linux
 
 ```sh
-export DOTFILES_GH_USER=ricardorsierra
-export DOTFILES_GH_BRANCH=master
+export DOTFILES_GH_USER=ricardosierra
+export DOTFILES_GH_BRANCH=release
 bash -c "$(wget -qO- https://raw.github.com/$DOTFILES_GH_USER/dotfiles/$DOTFILES_GH_BRANCH/bin/dotfiles) install" && source ~/.bashrc
 ```
 
@@ -145,8 +145,8 @@ Veja [Personalizando](docs/pt/Personalizando.md) para configurar variáveis e ad
 ### macOS
 
 ```sh
-export DOTFILES_GH_USER=ricardorsierra
-export DOTFILES_GH_BRANCH=master
+export DOTFILES_GH_USER=ricardosierra
+export DOTFILES_GH_BRANCH=release
 bash -c "$(curl -fsSL https://raw.github.com/$DOTFILES_GH_USER/dotfiles/$DOTFILES_GH_BRANCH/bin/dotfiles) install" && source ~/.bashrc
 ```
 
@@ -219,7 +219,7 @@ claude-set 3h29m 86%
 
 Because [`dotfiles`](bin/dotfiles) is self-contained, you can delete everything else from your fork and it will still work — it only needs `/copy`, `/link`, and `/init` (ignored if empty or missing).
 
-Found a bug? [File an issue](https://github.com/ricardorsierra/dotfiles/issues) or [open a PR](https://github.com/ricardorsierra/dotfiles/pulls).
+Found a bug? [File an issue](https://github.com/ricardosierra/dotfiles/issues) or [open a PR](https://github.com/ricardosierra/dotfiles/pulls).
 
 ---
 

--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -504,7 +504,7 @@ Usage:
 
 Description:
     See the README for documentation.
-    https://github.com/ricardorsierra/dotfiles
+    https://github.com/ricardosierra/dotfiles
 
     Is a fork then "Cowbow" Ben Alman <http://benalman.com/about/license/>
 
@@ -690,8 +690,8 @@ function git_update_dotfiles() {
     new_dotfiles_install=1
     prompt_delay=15
     e_header "Downloading dotfiles"
-    git clone --branch ${DOTFILES_GH_BRANCH:-master} --recursive \
-    git://github.com/${DOTFILES_GH_USER:-ricardorsierra}/dotfiles.git $DOTFILES
+    git clone --branch ${DOTFILES_GH_BRANCH:-release} --recursive \
+    git://github.com/${DOTFILES_GH_USER:-ricardosierra}/dotfiles.git $DOTFILES
     cd $DOTFILES
   elif [[ "$1" != "restart" ]]; then
     # Make sure we have the latest files.

--- a/link/.vim/nerdtree_plugin/expanderrific.vim
+++ b/link/.vim/nerdtree_plugin/expanderrific.vim
@@ -1,5 +1,5 @@
 " expanderrific.vim
-" https://github.com/ricardorsierra/dotfiles
+" https://github.com/ricardosierra/dotfiles
 "
 " Allow right/left to expand/collapse NERDTree dirs in a more meaningful way.
 


### PR DESCRIPTION
## Summary
- Corrige username `ricardorsierra` → `ricardosierra` em `bin/dotfiles`, `README.md` e `link/.vim/nerdtree_plugin/expanderrific.vim`
- Muda branch padrão de `master` para `release` no clone URL e no README

## Por que
O typo causava falha silenciosa no clone do dotfiles — `git_update_dotfiles` tentava clonar de `github.com/ricardorsierra/dotfiles` (repo inexistente) ao invés de `github.com/ricardosierra/dotfiles`.

## Test plan
- [ ] Instalação fresh funciona sem setar `DOTFILES_GH_USER` nem `DOTFILES_GH_BRANCH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)