### PR TITLE
fix(golang): define GOPATH para evitar Permission denied no install

### DIFF
--- a/init/60_golang.sh
+++ b/init/60_golang.sh
@@ -4,6 +4,7 @@ is_linux || is_osx || return 1
 
 export GO_VERSION=1.24.3
 export GO_SRC=/usr/local/go
+export GOPATH="${GOPATH:-$HOME/.go}"
 
 # if we are passing the version
 if [[ ! -z "$1" ]]; then


### PR DESCRIPTION
## Summary
- Adiciona `export GOPATH="${GOPATH:-$HOME/.go}"` no início de `init/60_golang.sh`

## Por que
Sem `GOPATH` definido no ambiente durante a instalação, o script tentava criar `/src/k8s.io` (diretório de root), falhando com:
```
mkdir: cannot create directory '/src': Permission denied
```

O dotfiles já define `GOPATH=$HOME/.go` em `source/01_exports.sh`, mas esse arquivo não é sourced durante a execução dos init scripts. O fix garante o mesmo valor sem depender do ambiente.

## Test plan
- [ ] `init/60_golang.sh` cria `$HOME/.go/src/...` em vez de `/src/...`
- [ ] Instalação em sistema novo não falha com Permission denied no passo golang

🤖 Generated with [Claude Code](https://claude.com/claude-code)